### PR TITLE
was changing mutable list by mistake

### DIFF
--- a/xsdata_odoo/filters.py
+++ b/xsdata_odoo/filters.py
@@ -143,7 +143,7 @@ class OdooFilters(Filters):
         """Should class or field be skipped?"""
         if parents is None:
             parents = []
-        class_skip = SIGNATURE_CLASS_SKIP
+        class_skip = SIGNATURE_CLASS_SKIP.copy()
         if os.environ.get("XSDATA_SKIP"):
             class_skip += os.environ["XSDATA_SKIP"].split("|")
         for pattern in class_skip:


### PR DESCRIPTION
the subtle bug was that class to be skipped set thorugh the XSDATA_SKIP ENV var would alter  the mutable SIGNATURE_CLASS_SKIP by mistake. Then inside generator.py, a whole file could be skipped if it contains on of the XSDATA_SKIP class because the generator would believe it was a file like xmldsig-core-schema.xsd  ...